### PR TITLE
Stop logging errors for expected use cases

### DIFF
--- a/dump_dbs.py
+++ b/dump_dbs.py
@@ -279,12 +279,10 @@ def main():
     for db in config:
         if type(config[db]) is str:
             continue
-        try:
-            # look up the local func named in method. We'll use that worker func.
-            methodfunc = globals()[config[db]["use"]]
-        except KeyError:
-            error(db + " has bad or missing \"use\" parameter, skipping")
+        method_name = config[db].get('use')
+        if not method_name:
             continue
+        methodfunc = globals()[method_name]
         methodfunc(config, db)
 
 if __name__ == "__main__":


### PR DESCRIPTION
This has apparently been "broken" since forever.
It's overly defensive programming; it complains about a
misconfiguration, even though the cannonical configuration triggers this
error message.

Since we don't expect all configuration entries to contain a `use` function,
let's gracefully ignore such cases.

This is intended to remove the necessity of https://github.com/Stanford-Online/dump-dbs/pull/5